### PR TITLE
Add p5 background animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.min.js"></script>
 </head>
 <body>
   <canvas id="starfield"></canvas>
@@ -140,6 +141,10 @@
   <script type="module">
     import { startStarfield } from './js/starfield.js';
     startStarfield(document.getElementById('starfield'));
+  </script>
+  <script type="module">
+    import { startP5Background } from './js/p5background.js';
+    startP5Background();
   </script>
 </body>
 </html>

--- a/js/p5background.js
+++ b/js/p5background.js
@@ -1,0 +1,38 @@
+export function startP5Background() {
+  new p5(sketch => {
+    let t = 0;
+
+    sketch.setup = () => {
+      const c = sketch.createCanvas(sketch.windowWidth, sketch.windowHeight);
+      c.position(0, 0);
+      c.style('z-index', '-2');
+      sketch.colorMode(sketch.HSB, 360, 100, 100, 100);
+      sketch.noFill();
+      sketch.blendMode(sketch.ADD);
+    };
+
+    sketch.windowResized = () => {
+      sketch.resizeCanvas(sketch.windowWidth, sketch.windowHeight);
+    };
+
+    sketch.draw = () => {
+      sketch.background(0, 0, 0, 10);
+      sketch.translate(sketch.width / 2, sketch.height / 2);
+      let prevX = null;
+      let prevY = null;
+      for (let i = 0; i < 600; i++) {
+        const a = i * 0.05 + t;
+        const r = 220 * sketch.sin(3 * a + t) * sketch.cos(4 * a - t);
+        const x = r * sketch.cos(a);
+        const y = r * sketch.sin(a);
+        if (prevX !== null) {
+          sketch.stroke((i * 2 + t * 50) % 360, 80, 100, 80);
+          sketch.line(prevX, prevY, x, y);
+        }
+        prevX = x;
+        prevY = y;
+      }
+      t += 0.005;
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- include p5.js library and start script
- implement mathematically complex p5 animation for homepage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68605133863c832a9c3a6f63d7a842fd