### PR TITLE
Add WebXR demo and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
       const PageComponent = pages[page];
       return (
         <div className="container">
-          <nav>
+          <nav className="fade-in">
             <button onClick={() => setPage('home')}>Home</button>
             <button onClick={() => setPage('about')}>About</button>
             <button onClick={() => setPage('blog')}>Blog</button>
@@ -127,7 +127,7 @@
             <button onClick={() => window.open('webxr-demo/', '_blank')}>WebXR Demo</button>
           </nav>
           <PageComponent />
-          <footer>
+          <footer className="fade-in">
             <button onClick={() => window.location='mailto:ajinkyagorad@gmail.com'}>Mail Me</button>
             <button onClick={() => window.open('https://github.com/ajinkyagorad','_blank')}>Github</button>
             <button onClick={() => window.open('https://twitter.com/ajinkya_gorad','_blank')}>Twitter</button>

--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
             <button onClick={() => setPage('about')}>About</button>
             <button onClick={() => setPage('blog')}>Blog</button>
             <button onClick={() => setPage('projects')}>Projects</button>
+            <button onClick={() => window.open('webxr-demo/', '_blank')}>WebXR Demo</button>
           </nav>
           <PageComponent />
           <footer>

--- a/webxr-demo/index.html
+++ b/webxr-demo/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WebXR Demo</title>
+  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/three@0.160.0/examples/jsm/webxr/VRButton.js"></script>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <script>
+    // Basic WebXR demo using Three.js
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.xr.enabled = true;
+    document.body.appendChild(renderer.domElement);
+    document.body.appendChild(VRButton.createButton(renderer));
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    camera.position.z = 2;
+    function animate() {
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    }
+    renderer.setAnimationLoop(animate);
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone WebXR demo using Three.js and VRButton
- link to the WebXR demo from main navigation

## Testing
- `npm test` *(fails: ENOENT open '/workspace/ajinkyagorad.github.io/package.json')*
- `npm run build` *(fails: ENOENT open '/workspace/ajinkyagorad.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c2a82a6060832a8e2846943243aa8b